### PR TITLE
fix: get요청에 바디 삭제 및 @RequestParam으로 요청 받기

### DIFF
--- a/src/main/java/com/popcorn/popcorn/controller/AuthController.java
+++ b/src/main/java/com/popcorn/popcorn/controller/AuthController.java
@@ -52,8 +52,8 @@ public class AuthController {
     }
 
     @GetMapping("/chkUser")
-    public ResponseEntity<ApiResponse<String>> chkUser(@RequestBody @Valid UsernameDto usernameDto){
-        boolean isExist = userService.isExistUsername(usernameDto.getUsername());
+    public ResponseEntity<ApiResponse<String>> chkUser(@RequestParam("username")String username){
+        boolean isExist = userService.isExistUsername(username);
         if(!isExist){
             return ResponseEntity.ok(ApiResponse.ok("사용 가능한 ID"));
         } else{
@@ -65,15 +65,17 @@ public class AuthController {
 
 
     @GetMapping("/validEmail")
-    public ResponseEntity<ApiResponse<String>> isExistByEmail(@RequestBody @Valid EmailRequestDto emailRequestDto){
+    public ResponseEntity<ApiResponse<String>> isExistByEmail(@RequestParam("email")String email){
         return ResponseEntity.status(HttpStatus.OK)
-                .body(userService.isExistByEmail(emailRequestDto.getEmail()));
+                .body(userService.isExistByEmail(email));
     }
 
     @GetMapping("/finduser")
-    public ResponseEntity<ApiResponse<String>> finduser(@RequestBody @Valid FindNameDto findNameDto){
-        String name = userService.findUserName(findNameDto.getName(), findNameDto.getEmail());
-        if(Objects.equals(name, "")){
+    public ResponseEntity<ApiResponse<String>> finduser(
+            @RequestParam("name")String name,
+            @RequestParam("email")String email){
+        String un = userService.findUserName(name, email);
+        if(Objects.equals(un, "")){
             return ResponseEntity.ok(ApiResponse.fail(NOT_FOUND_USER));
         }
         return ResponseEntity.ok(ApiResponse.ok(name));


### PR DESCRIPTION
get요청에 바디 삭제 및 RequestParam 어노테이션으로 요청 

> **_GET_**
/search?q=hello&hl=ko HTTP/1.1Host:www.google.com
해당 URL에 있는 자원을 주세요 !
리소스 조회
서버에 전달하고 싶은 데이터는 query(쿼리 파라미터, 쿼리 스트링)를 통해서 전달
GET에서 메세지 바디를 전달할수 있다 ( 최근 스펙에서 막지 않는다. But 실무에서는 하지 않는다. 필요한 경우 query파라미터나 스트링으로 전달 한다.
왜냐면 중간에 GET에 메세지 바디 전달하는걸 지원하지 않는 경우가 많다.